### PR TITLE
Fix handling of playlist files

### DIFF
--- a/download.rb
+++ b/download.rb
@@ -15,7 +15,7 @@ vod_id = url.split("/")[-1]
 token = JSON.parse(RestClient.get("https://api.twitch.tv/api/vods/#{vod_id}/access_token?as3=t"))
 playlist = RestClient.get("http://usher.justin.tv/vod/#{vod_id}?nauthsig=#{token["sig"]}&nauth=#{token["token"]}")
 
-vid_list_url = playlist.split("\n")[3]
+vid_list_url = playlist.split("\n").select{|l| l.start_with? "http"}[0]
 vid_list = RestClient.get(vid_list_url)
 dl_url = "http://#{vid_list_url.split("/")[2..-2].join("/")}"
 


### PR DESCRIPTION
Currently this script fails with:

```
Downloading http://www.twitch.tv/irongalaxy/v/27476461
/usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/uri/rfc3986_parser.rb:66:in `split': bad URI(is not URI?): http://#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2187507,CODECS="avc1.4D401F,mp4a.40.2",RESOLUTION="1280x720",VIDEO="chunked" (URI::InvalidURIError)
    from /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/uri/rfc3986_parser.rb:72:in `parse'
    from /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/uri/common.rb:226:in `parse'
    from /usr/local/lib/ruby/gems/2.2.0/gems/rest-client-1.8.0/lib/restclient/request.rb:276:in `parse_url'
    from /usr/local/lib/ruby/gems/2.2.0/gems/rest-client-1.8.0/lib/restclient/request.rb:280:in `parse_url_with_auth'
    from /usr/local/lib/ruby/gems/2.2.0/gems/rest-client-1.8.0/lib/restclient/request.rb:175:in `execute'
    from /usr/local/lib/ruby/gems/2.2.0/gems/rest-client-1.8.0/lib/restclient/request.rb:41:in `execute'
    from /usr/local/lib/ruby/gems/2.2.0/gems/rest-client-1.8.0/lib/restclient.rb:65:in `get'
    from download.rb:19:in `<main>'
```

This fixes it.
